### PR TITLE
ALLOW SETTING EMPTY LVMEXTENSION

### DIFF
--- a/lvmsnapshot.sh
+++ b/lvmsnapshot.sh
@@ -270,6 +270,7 @@ while getopts ':m:e:g:c:i:ndqh' OPTION ; do
 
         e)
             OPT_LVMEXTENSION=$OPTARG
+            ISSET_OPT_LVMEXTENSION="True"
             ;;
 
         c)
@@ -341,7 +342,7 @@ if [ ! -z $OPT_MAPPERINDEX ]; then
     MAPPERINDEX=$OPT_MAPPERINDEX
 fi
 
-if [ ! -z $OPT_LVMEXTENSION ]; then
+if [ ! -z $ISSET_OPT_LVMEXTENSION ]; then
     LVMEXTENSION=$OPT_LVMEXTENSION
 fi
 


### PR DESCRIPTION
The variable LVMEXTENSION is set by default to something like "-disk". If you
attempt to set an empty LVMEXTENSION using

    lvmsnapshot -e "" create <lvname>

Then the variable OPT_LVMEXTENSION will be empty when the command-line arguments are
parsed. This means that the following test will fail

    if [ ! -z $OPT_LVMEXTENSION ]; then

and LVMEXTENSION will continue to contain its default value. So I added an extra
flag that ISSET_OPT_LVMEXTENSION to show that the argument was parsed. This
allows for an empty LVMEXTENSION to be set using

    -e ""